### PR TITLE
fix: add `source "${CARGO_HOME:-$HOME/.cargo}/env"`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ runs:
         : install rustup if needed
         if ! command -v rustup &>/dev/null; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          source "${CARGO_HOME:-$HOME/.cargo}/env"
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
           rustup show active-toolchain
         fi


### PR DESCRIPTION
Hello, we use your repository for [Gear Protocol](https://github.com/gear-tech/gear). For some reason, one of our self-hosted runner can't find rustup (its configuration may differ from github runners). This PR fixes it.